### PR TITLE
Register Tenstorrent target

### DIFF
--- a/docs/tenstorrent/workstream1/ws1_target_registration.md
+++ b/docs/tenstorrent/workstream1/ws1_target_registration.md
@@ -22,4 +22,4 @@ Enable explicit opt-in for the Tenstorrent backend by adding `"tenstorrent"` to 
 ## Validation
 - Covered by `tests/python/tt/test_target_registration.py` (see Workstream 1 testing ticket).
 
-Status: TODO
+Status: In Review (changes pending on branch `tt-matmul-mvp-plan`)


### PR DESCRIPTION
## Summary
- add `tenstorrent` to TileLang target resolution and guard it behind TT backend registration
- expose detection helper so TT branches can short-circuit when backend is not built
- mark the Workstream 1 ticket doc as in review for the new change

## Testing
- not run (Tenstorrent backend not yet wired)
