### PR TITLE
CI improvements: Add TVM caching and yapf formatting

### DIFF
--- a/.github/workflows/tenstorrent-ci.yml
+++ b/.github/workflows/tenstorrent-ci.yml
@@ -76,6 +76,26 @@ jobs:
         python3 -m pip install --upgrade pip
         pip install pytest pytest-xdist
 
+    - name: Generate TVM cache key
+      id: tvm-cache-key
+      run: |
+        # Cache key based on TVM submodule commit hash
+        TVM_COMMIT=$(git rev-parse HEAD:3rdparty/tvm)
+        echo "tvm_commit=$TVM_COMMIT" >> $GITHUB_OUTPUT
+        echo "TVM submodule at commit: $TVM_COMMIT"
+
+    - name: Cache TVM build
+      id: cache-tvm
+      uses: actions/cache@v4
+      with:
+        path: |
+          build/libtvm*.so
+          build/3rdparty/
+        key: tvm-build-cuda-${{ steps.tvm-cache-key.outputs.tvm_commit }}-${{ runner.os }}
+        restore-keys: |
+          tvm-build-cuda-${{ steps.tvm-cache-key.outputs.tvm_commit }}-
+          tvm-build-cuda-
+
     - name: Build TileLang with CUDA
       run: |
         mkdir -p build
@@ -92,6 +112,7 @@ jobs:
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
         # Build (use fewer jobs to avoid OOM on GitHub runners)
+        # If cache hit, this will be much faster as TVM is already built
         cmake --build . --config Release -j 2
 
     - name: Install TileLang

--- a/.github/workflows/tenstorrent-ci.yml
+++ b/.github/workflows/tenstorrent-ci.yml
@@ -33,15 +33,17 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff black
+        pip install -r requirements-lint.txt
 
-    - name: Run ruff linter
+    - name: Run format.sh check
       run: |
-        ruff check tilelang/engine/tt/ testing/python/tt/ --output-format=github
-
-    - name: Run black formatter check
-      run: |
-        black --check tilelang/engine/tt/ testing/python/tt/
+        bash format.sh
+        # Check if format.sh made any changes
+        if ! git diff --quiet; then
+          echo "Code formatting issues found. Please run format.sh locally and commit the changes."
+          git diff
+          exit 1
+        fi
 
   build-and-test:
     runs-on: ubuntu-latest

--- a/testing/python/tt/test_target_registration.py
+++ b/testing/python/tt/test_target_registration.py
@@ -18,9 +18,7 @@ def toggle_tt_backend(monkeypatch):
     original = getattr(_target_mod, "_HAS_TENSTORRENT_BACKEND", False)
 
     def setter(value: bool):
-        monkeypatch.setattr(
-            _target_mod, "_HAS_TENSTORRENT_BACKEND", value, raising=False
-        )
+        monkeypatch.setattr(_target_mod, "_HAS_TENSTORRENT_BACKEND", value, raising=False)
 
     setter(original)
     try:
@@ -38,9 +36,7 @@ def test_determine_target_returns_target_when_backend_enabled(toggle_tt_backend)
     scope_name = _target_mod.determine_target(_target_mod.TENSTORRENT_TARGET)
     assert scope_name == _target_mod.TENSTORRENT_TARGET
 
-    target_obj = _target_mod.determine_target(
-        _target_mod.TENSTORRENT_TARGET, return_object=True
-    )
+    target_obj = _target_mod.determine_target(_target_mod.TENSTORRENT_TARGET, return_object=True)
     assert isinstance(target_obj, Target)
     assert target_obj.kind.name == _target_mod.TENSTORRENT_TARGET
 
@@ -54,8 +50,7 @@ def test_determine_target_raises_when_backend_disabled(toggle_tt_backend):
 def test_tenstorrent_engine_lower_raises_not_implemented(toggle_tt_backend):
     toggle_tt_backend(True)
     with pytest.raises(
-        NotImplementedError, match="Tenstorrent backend lowering is not yet implemented"
-    ):
+            NotImplementedError, match="Tenstorrent backend lowering is not yet implemented"):
         _tt_lower.lower(
             tvm.IRModule(),
             params=None,
@@ -69,9 +64,7 @@ def test_tenstorrent_engine_lower_raises_not_implemented(toggle_tt_backend):
 
 def test_tenstorrent_engine_lower_validates_target(toggle_tt_backend):
     toggle_tt_backend(True)
-    with pytest.raises(
-        ValueError, match="Tenstorrent lowering called with invalid target"
-    ):
+    with pytest.raises(ValueError, match="Tenstorrent lowering called with invalid target"):
         _tt_lower.lower(
             tvm.IRModule(),
             params=None,

--- a/tilelang/engine/tt/lower.py
+++ b/tilelang/engine/tt/lower.py
@@ -59,13 +59,9 @@ def lower(
     # Validate that we're actually targeting Tenstorrent
     target_kind = get_target_kind(target)
     if target_kind != TENSTORRENT_TARGET:
-        raise ValueError(
-            f"Tenstorrent lowering called with invalid target: {target_kind}. "
-            f"Expected: {TENSTORRENT_TARGET}"
-        )
+        raise ValueError(f"Tenstorrent lowering called with invalid target: {target_kind}. "
+                         f"Expected: {TENSTORRENT_TARGET}")
 
-    raise NotImplementedError(
-        "Tenstorrent backend lowering is not yet implemented. "
-        "This is a stub implementation. The lowering pipeline will be "
-        "added in future workstreams."
-    )
+    raise NotImplementedError("Tenstorrent backend lowering is not yet implemented. "
+                              "This is a stub implementation. The lowering pipeline will be "
+                              "added in future workstreams.")

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -12,6 +12,7 @@ def _is_tenstorrent_backend_enabled() -> bool:
     """Detect whether the Tenstorrent backend has been registered with TVM."""
     return bool(tvm.get_global_func("target.build.tilelang_tt", allow_missing=True))
 
+
 AVALIABLE_TARGETS = {
     "auto",
     "cuda",
@@ -21,7 +22,6 @@ AVALIABLE_TARGETS = {
     "llvm",
     TENSTORRENT_TARGET,
 }
-
 
 _HAS_TENSTORRENT_BACKEND = _is_tenstorrent_backend_enabled()
 
@@ -94,8 +94,7 @@ def determine_target(target: Union[str, Target, Literal["auto"]] = "auto",
             target, Target) or target_kind in AVALIABLE_TARGETS, f"Target {target} is not supported"
         if target_kind == TENSTORRENT_TARGET and not _HAS_TENSTORRENT_BACKEND:
             raise ValueError(
-                "Tenstorrent backend requires TileLang to be built with TL_TT_BACKEND enabled."
-            )
+                "Tenstorrent backend requires TileLang to be built with TL_TT_BACKEND enabled.")
         return_var = target
 
     if return_object:


### PR DESCRIPTION
## Summary
- Apply yapf formatting to Tenstorrent backend files
- Add TVM build caching to significantly reduce CI build times

## Details

### yapf formatting
Run `format.sh` to apply yapf formatting consistently across the codebase.

### TVM build caching
Cache TVM build artifacts based on the TVM submodule commit hash. This dramatically reduces CI build time for subsequent runs as long as the TVM submodule hasn't changed.

Cache strategy:
- Cache key includes TVM submodule commit hash and runner OS
- Caches built TVM libraries (`libtvm*.so`) and 3rdparty dependencies
- Uses GitHub Actions cache (up to 10GB per repo)
- Fallback restore keys for partial cache hits

## Test plan
- [x] yapf formatting applied
- [x] CI workflow builds successfully
- [ ] Verify cache hit on subsequent CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)