### PR TITLE
Replace heavy NVIDIA container with lightweight Ubuntu runner

### DIFF
--- a/.github/workflows/tenstorrent-ci.yml
+++ b/.github/workflows/tenstorrent-ci.yml
@@ -49,9 +49,6 @@ jobs:
 
   build-and-test:
     runs-on: ubuntu-latest
-    container:
-      image: nvcr.io/nvidia/pytorch:23.01-py3
-      options: --user root
 
     steps:
     - name: Checkout repository
@@ -60,38 +57,26 @@ jobs:
         fetch-depth: 0
         submodules: recursive
 
-    - name: Cache apt packages
-      uses: actions/cache@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        path: /var/cache/apt/archives
-        key: apt-${{ runner.os }}-build-deps-v1
+        python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'pip'
+        cache-dependency-path: 'requirements-test.txt'
 
-    - name: Install build dependencies
+    - name: Install system dependencies
       run: |
-        export DEBIAN_FRONTEND=noninteractive
-        export TZ=Etc/UTC
-        apt-get update
-        apt-get install -y \
+        sudo apt-get update
+        sudo apt-get install -y \
           build-essential \
           cmake \
           ninja-build \
-          git \
-          python3-dev \
-          zlib1g-dev \
-          libedit-dev \
-          libxml2-dev
+          llvm-dev \
+          libpolly-dev
 
-    - name: Cache pip packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: pip-${{ runner.os }}-${{ hashFiles('requirements-test.txt') }}
-        restore-keys: |
-          pip-${{ runner.os }}-
-
-    - name: Set up Python environment
+    - name: Install Python dependencies
       run: |
-        python3 -m pip install --upgrade pip
+        python -m pip install --upgrade pip
         pip install -r requirements-test.txt
 
     - name: Generate TVM cache key
@@ -109,19 +94,19 @@ jobs:
         path: |
           build/libtvm*.so
           build/3rdparty/
-        key: tvm-build-cuda-${{ steps.tvm-cache-key.outputs.tvm_commit }}-${{ runner.os }}
+        key: tvm-build-llvm-${{ steps.tvm-cache-key.outputs.tvm_commit }}-${{ runner.os }}
         restore-keys: |
-          tvm-build-cuda-${{ steps.tvm-cache-key.outputs.tvm_commit }}-
-          tvm-build-cuda-
+          tvm-build-llvm-${{ steps.tvm-cache-key.outputs.tvm_commit }}-
+          tvm-build-llvm-
 
-    - name: Build TileLang with CUDA
+    - name: Build TileLang with LLVM
       run: |
         mkdir -p build
         cd build
         # Create config.cmake for TVM
         cp ../3rdparty/tvm/cmake/config.cmake .
-        echo "set(USE_CUDA ON)" >> config.cmake
-        echo "set(USE_LLVM OFF)" >> config.cmake
+        echo "set(USE_LLVM ON)" >> config.cmake
+        echo "set(USE_CUDA OFF)" >> config.cmake
 
         # Configure with CMake
         cmake .. \

--- a/docs/tenstorrent/CI.md
+++ b/docs/tenstorrent/CI.md
@@ -29,40 +29,35 @@ The Tenstorrent backend CI is defined in `.github/workflows/tenstorrent-ci.yml` 
 
 ### 2. Build and Test (`build-and-test`)
 
-**Environment:** NVIDIA PyTorch container (`nvcr.io/nvidia/pytorch:23.01-py3`)
+**Environment:** Ubuntu runner with Python 3.10
 
-**Purpose:** Build TileLang with CUDA backend and run Tenstorrent tests
+**Purpose:** Build TileLang with LLVM backend and run Tenstorrent tests
 
-**Why use a container?**
-- Pre-installed CUDA toolkit and cuDNN
-- Complete build environment with Python and development tools
-- Consistent environment across CI runs
+**Note:** Currently builds with LLVM backend (not CUDA) since we only run CPU tests at this stage. This keeps the CI lightweight and fast. GPU/CUDA testing will be added in future when needed.
 
 **Steps:**
 1. Checkout repository with submodules
-2. Cache apt packages (build dependencies)
-3. Install build dependencies: cmake, ninja, git, python3-dev, etc.
-4. Cache pip packages (pytest, pytest-xdist)
-5. Set up Python environment
-6. **TVM Build Caching:**
+2. Set up Python with pip caching (caches `requirements-test.txt` dependencies)
+3. Install system dependencies: cmake, ninja, llvm-dev, libpolly-dev
+4. Install Python dependencies from requirements-test.txt
+5. **TVM Build Caching:**
    - Generate cache key based on TVM submodule commit hash
    - Restore cached TVM build artifacts if available
    - Caches: `build/libtvm*.so` and `build/3rdparty/`
    - Only rebuilds TVM when the submodule is updated
-7. Build TileLang with CUDA backend
+6. Build TileLang with LLVM backend
    - Uses Ninja build system
    - Limited to 2 parallel jobs to avoid OOM on GitHub runners
-8. Install TileLang in development mode
-9. Run Tenstorrent target registration tests
-10. Run all Tenstorrent Python tests (CPU-only)
+   - LLVM backend is sufficient for CPU-only testing
+7. Install TileLang in development mode
+8. Run Tenstorrent target registration tests
+9. Run all Tenstorrent Python tests (CPU-only)
 
 **Caching Strategy:**
 - **TVM build artifacts:** Keyed by TVM submodule commit + OS
   - Dramatically reduces build time (TVM build is expensive)
   - Only invalidates when TVM submodule is updated
-- **Apt packages:** Keyed by OS + build deps version
-  - Speeds up dependency installation
-- **Pip packages:** Keyed by requirements file hash
+- **Pip packages:** Keyed by requirements-test.txt hash
   - Reuses cached pytest and other test dependencies
 
 ### 3. Static Analysis (`static-analysis`)
@@ -89,8 +84,7 @@ The CI uses multiple layers of caching for efficiency:
 |-----|---------------|-----------|---------|
 | lint-and-format | Pip packages | requirements-lint.txt hash | Fast linter installation |
 | build-and-test | TVM build | TVM submodule commit + OS | Avoid rebuilding TVM (~30+ min) |
-| build-and-test | Apt packages | OS + deps version | Fast apt install |
-| build-and-test | Pip packages | requirements hash | Fast pytest install |
+| build-and-test | Pip packages | requirements-test.txt hash | Fast pytest install |
 | static-analysis | Pip packages | requirements-mypy.txt hash | Fast mypy installation |
 
 ## Running Locally
@@ -131,6 +125,7 @@ CI runs automatically on:
 ## Future Improvements
 
 Potential optimizations:
+- Add CUDA build and GPU testing when needed (will require NVIDIA container or GPU runners)
 - Custom Docker image with pre-built TVM (eliminates TVM build entirely)
 - Parallel test execution with pytest-xdist
 - Separate workflow for expensive builds (only on main/release branches)


### PR DESCRIPTION
## Summary
Remove the heavy NVIDIA PyTorch container and switch to a lightweight Ubuntu runner with LLVM backend for CI.

## Problem
The NVIDIA PyTorch container (~5GB) takes a long time to set up in CI, but we're only running CPU tests at this stage - we don't need CUDA, PyTorch, or GPU support.

## Solution
- Use plain `ubuntu-latest` runner instead of NVIDIA container
- Build TVM with LLVM backend (not CUDA)
- Use `setup-python` action with built-in pip caching
- Remove unnecessary apt package caching (handled by GitHub's caching)

## Benefits
- **Faster CI startup:** No need to pull/extract 5GB container image
- **Simpler setup:** Standard Ubuntu runner with Python action
- **Same functionality:** LLVM backend is sufficient for CPU-only tests
- **Easier to maintain:** Standard GitHub Actions patterns

## Testing
Tests remain the same - we're still running CPU-only Tenstorrent tests, just with a lighter build environment.

## Future
When GPU/CUDA testing is needed, we can add it back as a separate job with appropriate GPU runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)