### PR TITLE
Add cache hit logging to Tenstorrent CI workflow

### DIFF
--- a/.github/workflows/tenstorrent-ci.yml
+++ b/.github/workflows/tenstorrent-ci.yml
@@ -101,6 +101,9 @@ jobs:
           tvm-build-llvm-${{ steps.tvm-cache-key.outputs.tvm_commit }}-
           tvm-build-llvm-
 
+    - name: Log TVM cache status
+      run: echo "TVM cache hit: ${{ steps.cache-tvm.outputs.cache-hit }}"
+
     - name: Build TileLang with LLVM
       run: |
         mkdir -p build


### PR DESCRIPTION
This PR adds logging for TVM build cache hit status to improve CI visibility. Since apt caching has been removed, this focuses on the existing TVM cache.\n\nImplements suggestion to emit logs on cache hit successes.