### PR TITLE
Fix CI: Disable WITH_COMMITID to skip nvcc check

### DIFF
--- a/.github/workflows/tenstorrent-ci.yml
+++ b/.github/workflows/tenstorrent-ci.yml
@@ -127,8 +127,11 @@ jobs:
         cp build/*.so tilelang/lib/ || true
 
         # Install Python package in development mode
-        # Set dummy CUDA_HOME to satisfy setup.py check (we're using LLVM)
+        # Set USE_LLVM=true for LLVM build, dummy CUDA_HOME to pass validation,
+        # and disable commit ID to avoid nvcc check
+        export USE_LLVM=true
         export CUDA_HOME=/usr
+        export WITH_COMMITID=False
         pip install -e .
 
     - name: Run Tenstorrent target registration tests


### PR DESCRIPTION
## Problem
CI fails during pip install with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/nvcc'
```

setup.py tries to run nvcc to get the CUDA version when building the version string with commit ID.

## Solution
Set `WITH_COMMITID=False` to skip the version string generation that requires nvcc.

This allows pip install to succeed in the LLVM-only CI environment without CUDA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)