### PR TITLE
Phase 2 WS3: Implement TilePadTT pass

### DIFF
--- a/src/transform/tt/tile_pad_tt.cc
+++ b/src/transform/tt/tile_pad_tt.cc
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file tile_pad_tt.cc
+ * \brief Insert padding for non-tile-aligned buffers (WS3 Phase 2)
+ *
+ * This pass handles buffers with dimensions that are not multiples of the
+ * tile size (typically 32). It annotates the IR with padding metadata that
+ * will be used during codegen to properly handle boundary tiles.
+ *
+ * Padding Strategy:
+ * - For buffers with needs_padding=1 (from WS2), compute padded dimensions
+ * - Padded dimension = ceil(original_dim / tile_size) * tile_size
+ * - Stamp padded_shape metadata for use in memory allocation
+ * - For Phase 2, actual padding logic will be in codegen
+ *
+ * Example: 250×250 buffer with tile_size=32
+ * - Original: 250×250
+ * - Num tiles: ceil(250/32) = 8 tiles per dimension
+ * - Padded: 8*32 = 256×256
+ * - Padding: 6 extra elements per dimension
+ *
+ * See: docs/tenstorrent/UNIFIED_MATMUL_MVP_PLAN.md Phase 2 WS3-Extended
+ */
+
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/tir/function.h>
+#include <tvm/tir/transform.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+/*!
+ * \brief Padding information for a buffer
+ */
+struct PaddingInfo {
+  Array<Integer> original_shape;
+  Array<Integer> padded_shape;
+  Array<Integer> padding_amount;  // Per dimension
+  bool needs_padding;
+};
+
+/*!
+ * \brief Compute padding for non-tile-aligned dimensions
+ *
+ * \param original_dim Original dimension size
+ * \param tile_size Tile size (typically 32)
+ * \return Padded dimension size
+ */
+int64_t ComputePaddedDim(int64_t original_dim, int tile_size = 32) {
+  // Compute number of tiles needed
+  int64_t num_tiles = (original_dim + tile_size - 1) / tile_size;
+
+  // Padded dimension is num_tiles * tile_size
+  return num_tiles * tile_size;
+}
+
+/*!
+ * \brief Extract padding info from WS2 metadata
+ *
+ * \param f The PrimFunc with WS2 sharding metadata
+ * \param param The buffer parameter to check
+ * \param param_name Buffer parameter name
+ * \return PaddingInfo structure
+ */
+PaddingInfo ExtractPaddingInfo(const PrimFunc& f, const Buffer& param, const std::string& param_name) {
+  PaddingInfo info;
+  info.needs_padding = false;
+
+  // Check for WS2 padding metadata
+  std::string needs_padding_key = "tt_buffer_" + param_name + "_needs_padding";
+  auto needs_padding_attr = f->attrs.GetAttr<Integer>(needs_padding_key);
+
+  if (!needs_padding_attr.defined()) {
+    return info;  // No WS2 metadata for this buffer
+  }
+
+  bool needs_padding = needs_padding_attr.value()->value != 0;
+  info.needs_padding = needs_padding;
+
+  if (!needs_padding) {
+    // Already tile-aligned, no padding needed
+    info.original_shape.clear();
+    for (const auto& dim : param->shape) {
+      if (auto dim_int = dim.as<IntImmNode>()) {
+        info.original_shape.push_back(Integer(dim_int->value));
+        info.padded_shape.push_back(Integer(dim_int->value));
+        info.padding_amount.push_back(Integer(0));
+      }
+    }
+    return info;
+  }
+
+  // Extract tile shape from WS2 metadata
+  std::string tile_shape_key = "tt_buffer_" + param_name + "_tile_shape";
+  auto tile_shape_attr = f->attrs.GetAttr<Array<Integer>>(tile_shape_key);
+
+  int tile_height = 32;  // Default
+  int tile_width = 32;
+
+  if (tile_shape_attr.defined() && tile_shape_attr.value().size() >= 2) {
+    tile_height = static_cast<int>(tile_shape_attr.value()[0]->value);
+    tile_width = static_cast<int>(tile_shape_attr.value()[1]->value);
+  }
+
+  // Compute padded dimensions
+  for (size_t i = 0; i < param->shape.size(); ++i) {
+    if (auto dim_int = param->shape[i].as<IntImmNode>()) {
+      int64_t original = dim_int->value;
+      int tile_size = (i == 0) ? tile_height : tile_width;
+      int64_t padded = ComputePaddedDim(original, tile_size);
+      int64_t padding = padded - original;
+
+      info.original_shape.push_back(Integer(original));
+      info.padded_shape.push_back(Integer(padded));
+      info.padding_amount.push_back(Integer(padding));
+    }
+  }
+
+  return info;
+}
+
+/*!
+ * \brief Main implementation of TilePadTT pass
+ *
+ * Computes padding metadata for non-tile-aligned buffers.
+ * Attaches padded shape information to function attributes for use in codegen.
+ *
+ * \param f The PrimFunc to process
+ * \return Enhanced PrimFunc with padding metadata
+ */
+PrimFunc TilePadTTImpl(PrimFunc f) {
+  // Step 1: Check if this is a TT function with WS2 metadata
+  auto schedule_policy = f->attrs.GetAttr<String>("tt_schedule_policy");
+  if (!schedule_policy.defined()) {
+    // Not a TT function, skip transformation
+    return f;
+  }
+
+  // Step 2: Process each buffer parameter
+  std::unordered_map<std::string, PaddingInfo> padding_map;
+
+  for (const auto& param : f->params) {
+    if (auto buf = f->buffer_map.Get(param)) {
+      std::string param_name = param->name_hint;
+      PaddingInfo info = ExtractPaddingInfo(f, buf.value(), param_name);
+
+      if (info.needs_padding) {
+        padding_map[param_name] = info;
+      }
+    }
+  }
+
+  // If no buffers need padding, return unchanged
+  if (padding_map.empty()) {
+    return f;
+  }
+
+  // Step 3: Build padding metadata for function attributes
+  Map<String, ObjectRef> padding_metadata;
+
+  for (const auto& pair : padding_map) {
+    const std::string& buf_name = pair.first;
+    const PaddingInfo& info = pair.second;
+
+    // Create metadata for this buffer
+    Map<String, ObjectRef> buf_metadata;
+    buf_metadata.Set("needs_padding", Bool(info.needs_padding));
+    buf_metadata.Set("original_shape", info.original_shape);
+    buf_metadata.Set("padded_shape", info.padded_shape);
+    buf_metadata.Set("padding_amount", info.padding_amount);
+
+    padding_metadata.Set(buf_name, buf_metadata);
+  }
+
+  // Step 4: Attach padding metadata to function
+  PrimFunc new_func = WithAttr(f, "tt_padding_info", padding_metadata);
+
+  return new_func;
+}
+
+using namespace tir::transform;
+
+/*!
+ * \brief Create the TilePadTT pass
+ *
+ * \return The TIR pass
+ */
+Pass TilePadTT() {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+    return TilePadTTImpl(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.TilePadTT", {});
+}
+
+// Register the pass for Python FFI
+TVM_FFI_STATIC_INIT_BLOCK({
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tl.transform.TilePadTT", TilePadTT);
+});
+
+}  // namespace tl
+}  // namespace tvm

--- a/testing/python/tt/test_tile_pad_tt.py
+++ b/testing/python/tt/test_tile_pad_tt.py
@@ -1,0 +1,250 @@
+"""Test TilePadTT pass (WS3 Phase 2).
+
+This pass computes padding metadata for non-tile-aligned buffers.
+"""
+
+import pytest
+import tvm
+from tvm import tir
+
+
+def create_func_with_padding_metadata(needs_padding=True):
+    """Create a mock PrimFunc with WS2 padding metadata."""
+    # Create buffers - 250×250 if padding needed, 256×256 if aligned
+    if needs_padding:
+        A = tir.decl_buffer((250, 250), "float16", name="A", scope="global")
+    else:
+        A = tir.decl_buffer((256, 256), "float16", name="A", scope="global")
+
+    B = tir.decl_buffer((256, 256), "float16", name="B", scope="global")
+    C = tir.decl_buffer((256, 256), "float16", name="C", scope="global")
+
+    body = tir.Evaluate(0)
+    func = tir.PrimFunc([A, B, C], body)
+
+    # Add TT defaults
+    func = func.with_attr("tt_schedule_policy", "contiguous")
+
+    # Add WS2 padding metadata
+    func = func.with_attr("tt_buffer_A_needs_padding", tvm.tir.IntImm("int32", 1 if needs_padding else 0))
+    func = func.with_attr("tt_buffer_A_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    func = func.with_attr("tt_buffer_B_needs_padding", tvm.tir.IntImm("int32", 0))
+    func = func.with_attr("tt_buffer_B_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    func = func.with_attr("tt_buffer_C_needs_padding", tvm.tir.IntImm("int32", 0))
+    func = func.with_attr("tt_buffer_C_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    return func
+
+
+def test_tile_pad_tt_basic():
+    """Test TilePadTT generates padding metadata."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    func = create_func_with_padding_metadata(needs_padding=True)
+    mod = tvm.IRModule({"main": func})
+
+    # Apply TilePadTT
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    # Verify padding metadata attached
+    assert func.attrs is not None, "Function should have attributes"
+    assert "tt_padding_info" in func.attrs, "Should have tt_padding_info attribute"
+
+
+def test_tile_pad_tt_padded_dimensions():
+    """Test TilePadTT computes correct padded dimensions."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    func = create_func_with_padding_metadata(needs_padding=True)
+    mod = tvm.IRModule({"main": func})
+
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    padding_info = func.attrs["tt_padding_info"]
+
+    # Check buffer A (250×250 → 256×256)
+    assert "A" in padding_info, "Should have padding info for buffer A"
+
+    a_info = padding_info["A"]
+    assert "needs_padding" in a_info, "Should have needs_padding flag"
+    assert bool(a_info["needs_padding"]), "Buffer A should need padding"
+
+    assert "padded_shape" in a_info, "Should have padded_shape"
+    padded_shape = a_info["padded_shape"]
+    assert len(padded_shape) == 2, "Padded shape should be 2D"
+    assert int(padded_shape[0]) == 256, f"Expected padded height 256, got {int(padded_shape[0])}"
+    assert int(padded_shape[1]) == 256, f"Expected padded width 256, got {int(padded_shape[1])}"
+
+
+def test_tile_pad_tt_padding_amount():
+    """Test TilePadTT calculates correct padding amounts."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    func = create_func_with_padding_metadata(needs_padding=True)
+    mod = tvm.IRModule({"main": func})
+
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    padding_info = func.attrs["tt_padding_info"]
+    a_info = padding_info["A"]
+
+    assert "padding_amount" in a_info, "Should have padding_amount"
+    padding_amount = a_info["padding_amount"]
+
+    # For 250×250 → 256×256, padding is 6 per dimension
+    assert len(padding_amount) == 2, "Padding amount should be 2D"
+    assert int(padding_amount[0]) == 6, f"Expected padding 6 for height, got {int(padding_amount[0])}"
+    assert int(padding_amount[1]) == 6, f"Expected padding 6 for width, got {int(padding_amount[1])}"
+
+
+def test_tile_pad_tt_original_shape():
+    """Test TilePadTT preserves original shape."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    func = create_func_with_padding_metadata(needs_padding=True)
+    mod = tvm.IRModule({"main": func})
+
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    padding_info = func.attrs["tt_padding_info"]
+    a_info = padding_info["A"]
+
+    assert "original_shape" in a_info, "Should have original_shape"
+    original_shape = a_info["original_shape"]
+
+    assert len(original_shape) == 2, "Original shape should be 2D"
+    assert int(original_shape[0]) == 250, f"Expected original height 250, got {int(original_shape[0])}"
+    assert int(original_shape[1]) == 250, f"Expected original width 250, got {int(original_shape[1])}"
+
+
+def test_tile_pad_tt_skip_aligned_buffers():
+    """Test TilePadTT skips already aligned buffers."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    func = create_func_with_padding_metadata(needs_padding=False)
+    mod = tvm.IRModule({"main": func})
+
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    # Should not add padding_info if no buffers need padding
+    if "tt_padding_info" in func.attrs:
+        padding_info = func.attrs["tt_padding_info"]
+        # Buffer A is aligned (256×256), should not be in padding_info
+        assert "A" not in padding_info, "Aligned buffer A should not have padding info"
+
+
+def test_tile_pad_tt_skip_non_tt_functions():
+    """Test TilePadTT skips functions without TT attributes."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    # Create function WITHOUT TT attributes
+    A = tir.decl_buffer((250, 250), "float16", name="A")
+    body = tir.Evaluate(0)
+    func = tir.PrimFunc([A], body)
+
+    mod = tvm.IRModule({"main": func})
+
+    # Apply pass
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    # Should NOT add padding metadata
+    assert func.attrs is None or "tt_padding_info" not in func.attrs, "Should not add padding without TT attributes"
+
+
+def test_tile_pad_tt_multiple_buffers():
+    """Test TilePadTT handles multiple buffers with different padding needs."""
+    from tilelang.tt.passes import tile_pad_tt
+
+    # Create buffers with different padding needs
+    A = tir.decl_buffer((250, 250), "float16", name="A", scope="global")  # Needs padding
+    B = tir.decl_buffer((100, 100), "float16", name="B", scope="global")  # Needs padding
+    C = tir.decl_buffer((256, 256), "float16", name="C", scope="global")  # Aligned
+
+    body = tir.Evaluate(0)
+    func = tir.PrimFunc([A, B, C], body)
+
+    # Add TT defaults
+    func = func.with_attr("tt_schedule_policy", "contiguous")
+
+    # Add WS2 metadata
+    func = func.with_attr("tt_buffer_A_needs_padding", tvm.tir.IntImm("int32", 1))
+    func = func.with_attr("tt_buffer_A_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    func = func.with_attr("tt_buffer_B_needs_padding", tvm.tir.IntImm("int32", 1))
+    func = func.with_attr("tt_buffer_B_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    func = func.with_attr("tt_buffer_C_needs_padding", tvm.tir.IntImm("int32", 0))
+    func = func.with_attr("tt_buffer_C_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+
+    mod = tvm.IRModule({"main": func})
+
+    mod = tile_pad_tt(mod)
+    func = mod["main"]
+
+    padding_info = func.attrs["tt_padding_info"]
+
+    # Should have info for A and B, not C
+    assert "A" in padding_info, "Should have padding info for buffer A"
+    assert "B" in padding_info, "Should have padding info for buffer B"
+    assert "C" not in padding_info, "Aligned buffer C should not have padding info"
+
+    # Check A: 250×250 → 256×256
+    a_padded = padding_info["A"]["padded_shape"]
+    assert int(a_padded[0]) == 256 and int(a_padded[1]) == 256
+
+    # Check B: 100×100 → 128×128 (4 tiles per dimension)
+    b_padded = padding_info["B"]["padded_shape"]
+    assert int(b_padded[0]) == 128 and int(b_padded[1]) == 128
+
+
+def test_tile_pad_tt_integration_with_ws1_ws2():
+    """Test TilePadTT integrates with full WS1→WS2→TilePadTT pipeline."""
+    from tilelang.tt.passes import apply_ws2_passes, tile_pad_tt
+    from tilelang.tt.target import apply_tt_defaults
+
+    # Create function with non-aligned buffer
+    A = tir.decl_buffer((250, 250), "float16", name="A", scope="global")
+    B = tir.decl_buffer((256, 256), "float16", name="B", scope="global")
+    C = tir.decl_buffer((256, 256), "float16", name="C", scope="global")
+
+    body = tir.Evaluate(0)
+    func = tir.PrimFunc([A, B, C], body)
+
+    # Add grid metadata (normally from TileLang frontend)
+    func = func.with_attr("tl.grid_x", tvm.tir.IntImm("int32", 8))
+    func = func.with_attr("tl.grid_y", tvm.tir.IntImm("int32", 8))
+
+    mod = tvm.IRModule({"main": func})
+
+    # Apply WS1 → WS2 → TilePadTT
+    mod = apply_tt_defaults(mod)
+    mod = apply_ws2_passes(mod)
+    mod = tile_pad_tt(mod)
+
+    func = mod["main"]
+
+    # Verify all metadata exists
+    assert "tt_schedule_policy" in func.attrs, "Should have WS1 defaults"
+    assert "tt_buffer_A_needs_padding" in func.attrs, "Should have WS2 padding detection"
+    assert "tt_padding_info" in func.attrs, "Should have TilePadTT output"
+
+
+if __name__ == "__main__":
+    # Run tests
+    test_tile_pad_tt_basic()
+    test_tile_pad_tt_padded_dimensions()
+    test_tile_pad_tt_padding_amount()
+    test_tile_pad_tt_original_shape()
+    test_tile_pad_tt_skip_aligned_buffers()
+    test_tile_pad_tt_skip_non_tt_functions()
+    test_tile_pad_tt_multiple_buffers()
+    test_tile_pad_tt_integration_with_ws1_ws2()
+    print("All TilePadTT tests passed!")


### PR DESCRIPTION
## Summary

This PR implements the **TilePadTT** transformation for Phase 2 WS3, which computes padding metadata for non-tile-aligned buffers to enable proper boundary tile handling during codegen.

## Changes

### C++ Implementation
- **`src/transform/tt/tile_pad_tt.cc`**
  - `ComputePaddedDim(original_dim, tile_size)`: Calculates padded dimension using ceiling division
  - `ExtractPaddingInfo(func, buffer, name)`: Reads WS2 padding flags and computes padding metadata
  - `TilePadTTImpl(func)`: Main pass - processes all buffer parameters
  - Generates `tt_padding_info` metadata map
  - TVM FFI registration: `tl.transform.TilePadTT`

### Python Bindings
- **`tilelang/tt/passes.py`**
  - Added `tile_pad_tt()` function with comprehensive docstring
  - Integrated into `apply_ws3_passes()` pipeline (after MemorySpaceLowerTT)

### Tests
- **`testing/python/tt/test_tile_pad_tt.py`** - 8 comprehensive tests
  - `test_tile_pad_tt_basic`: Verifies metadata generation
  - `test_tile_pad_tt_padded_dimensions`: 250×250 → 256×256
  - `test_tile_pad_tt_padding_amount`: Validates padding calculation (6 per dim)
  - `test_tile_pad_tt_original_shape`: Preserves original dimensions
  - `test_tile_pad_tt_skip_aligned_buffers`: Skips 256×256 (already aligned)
  - `test_tile_pad_tt_skip_non_tt_functions`: Graceful skip without TT attrs
  - `test_tile_pad_tt_multiple_buffers`: Different padding per buffer (250→256, 100→128)
  - `test_tile_pad_tt_integration_with_ws1_ws2`: Full pipeline integration

## Test Results

**58/61 tests passing** (8 new TilePadTT tests, all passing)

```
tt/test_tile_pad_tt.py::test_tile_pad_tt_basic PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_padded_dimensions PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_padding_amount PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_original_shape PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_skip_aligned_buffers PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_skip_non_tt_functions PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_multiple_buffers PASSED
tt/test_tile_pad_tt.py::test_tile_pad_tt_integration_with_ws1_ws2 PASSED
```

3 failures are expected MVP acceptance tests (require TileLang frontend integration).

## Technical Details

**Input Metadata (from WS2):**
- `tt_buffer_*_needs_padding`: Boolean flag (0 or 1)
- `tt_buffer_*_tile_shape`: Tile dimensions `[height, width]`

**Output Metadata:**
- `tt_padding_info`: Map of buffer_name → padding details
  ```cpp
  {
    "buffer_name": {
      "needs_padding": Bool(true/false),
      "original_shape": Array[Integer],  // e.g., [250, 250]
      "padded_shape": Array[Integer],    // e.g., [256, 256]
      "padding_amount": Array[Integer]   // e.g., [6, 6]
    }
  }
  ```

**Padding Algorithm:**
```cpp
padded_dim = ceil(original_dim / tile_size) * tile_size
           = ((original_dim + tile_size - 1) / tile_size) * tile_size

Examples:
- 250 / 32 → 8 tiles → 8*32 = 256 (padding: 6)
- 100 / 32 → 4 tiles → 4*32 = 128 (padding: 28)
- 256 / 32 → 8 tiles → 8*32 = 256 (padding: 0, no metadata generated)
```

**Integration:**
- Automatically picked up by CMake (`src/transform/tt/*.cc` glob)
- Called in `apply_ws3_passes()` after `memory_space_lower_tt()`
- Metadata-only pass (no IR body modifications)
- Actual padding logic deferred to codegen (Phase 2 WS4-6)
- Phase 2 transform (deferred from Phase 1 MVP per UNIFIED_MATMUL_MVP_PLAN.md)

## Checklist

- [x] C++ implementation complete
- [x] Python bindings complete
- [x] Tests written and passing (8/8 tests)
- [x] Documentation complete (comprehensive docstrings)
- [x] Code formatted
- [x] All existing tests still pass (58/61, 3 expected failures)
- [x] Integrated into WS3 pipeline

## Related Work

Part of Phase 2 WS3 transforms:
- ✅ GridToPersistentTT (Phase 1)
- ✅ TTShardToCoreMap (PR #33)
- ✅ MemorySpaceLowerTT (PR #34)
- ✅ TilePadTT (this PR)
- ⏳ TensorizeTT (next)
- ⏳ VerifyTTIR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)