### PR TITLE
Phase 2 WS4-6: Fix MVP acceptance tests and apply formatting

### DIFF
--- a/testing/python/tt/test_memory_space_lower_tt.py
+++ b/testing/python/tt/test_memory_space_lower_tt.py
@@ -21,16 +21,7 @@ def create_func_with_tile_buffers():
     C_tile = tir.decl_buffer((32, 32), "float16", name="C_tile")
 
     # Simple body with DeclBuffer statements
-    body = tir.DeclBuffer(
-        A_tile,
-        tir.DeclBuffer(
-            B_tile,
-            tir.DeclBuffer(
-                C_tile,
-                tir.Evaluate(0)
-            )
-        )
-    )
+    body = tir.DeclBuffer(A_tile, tir.DeclBuffer(B_tile, tir.DeclBuffer(C_tile, tir.Evaluate(0))))
 
     func = tir.PrimFunc([A, B, C], body)
 
@@ -165,16 +156,8 @@ def test_memory_space_lower_tt_skip_non_tile_buffers():
     # Scalar buffer (should be skipped)
     scalar_buf = tir.decl_buffer((1,), "float16", name="scalar")
 
-    body = tir.DeclBuffer(
-        A_tile,
-        tir.DeclBuffer(
-            large_buf,
-            tir.DeclBuffer(
-                scalar_buf,
-                tir.Evaluate(0)
-            )
-        )
-    )
+    body = tir.DeclBuffer(A_tile,
+                          tir.DeclBuffer(large_buf, tir.DeclBuffer(scalar_buf, tir.Evaluate(0))))
 
     func = tir.PrimFunc([A], body)
     func = func.with_attr("tt_schedule_policy", "contiguous")
@@ -203,16 +186,7 @@ def test_memory_space_lower_tt_integration_with_ws1_ws2():
     B_tile = tir.decl_buffer((32, 32), "float16", name="B_tile")
     C_tile = tir.decl_buffer((32, 32), "float16", name="C_tile")
 
-    body = tir.DeclBuffer(
-        A_tile,
-        tir.DeclBuffer(
-            B_tile,
-            tir.DeclBuffer(
-                C_tile,
-                tir.Evaluate(0)
-            )
-        )
-    )
+    body = tir.DeclBuffer(A_tile, tir.DeclBuffer(B_tile, tir.DeclBuffer(C_tile, tir.Evaluate(0))))
 
     func = tir.PrimFunc([A, B, C], body)
 
@@ -248,16 +222,8 @@ def test_memory_space_lower_tt_different_tile_sizes():
     tile_32x32 = tir.decl_buffer((32, 32), "float32", name="tile_32x32")
     tile_64x64 = tir.decl_buffer((64, 64), "float32", name="tile_64x64")
 
-    body = tir.DeclBuffer(
-        tile_16x16,
-        tir.DeclBuffer(
-            tile_32x32,
-            tir.DeclBuffer(
-                tile_64x64,
-                tir.Evaluate(0)
-            )
-        )
-    )
+    body = tir.DeclBuffer(tile_16x16,
+                          tir.DeclBuffer(tile_32x32, tir.DeclBuffer(tile_64x64, tir.Evaluate(0))))
 
     func = tir.PrimFunc([A], body)
     func = func.with_attr("tt_schedule_policy", "contiguous")
@@ -282,7 +248,8 @@ def test_memory_space_lower_tt_different_tile_sizes():
     for config in cb_configs:
         name = str(config["name"])
         tile_size = int(config["tile_size"])
-        assert tile_size == expected_sizes[name], f"{name}: expected {expected_sizes[name]}, got {tile_size}"
+        assert tile_size == expected_sizes[
+            name], f"{name}: expected {expected_sizes[name]}, got {tile_size}"
 
 
 if __name__ == "__main__":

--- a/testing/python/tt/test_tile_pad_tt.py
+++ b/testing/python/tt/test_tile_pad_tt.py
@@ -26,14 +26,21 @@ def create_func_with_padding_metadata(needs_padding=True):
     func = func.with_attr("tt_schedule_policy", "contiguous")
 
     # Add WS2 padding metadata
-    func = func.with_attr("tt_buffer_A_needs_padding", tvm.tir.IntImm("int32", 1 if needs_padding else 0))
-    func = func.with_attr("tt_buffer_A_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr("tt_buffer_A_needs_padding",
+                          tvm.tir.IntImm("int32", 1 if needs_padding else 0))
+    func = func.with_attr(
+        "tt_buffer_A_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     func = func.with_attr("tt_buffer_B_needs_padding", tvm.tir.IntImm("int32", 0))
-    func = func.with_attr("tt_buffer_B_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr(
+        "tt_buffer_B_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     func = func.with_attr("tt_buffer_C_needs_padding", tvm.tir.IntImm("int32", 0))
-    func = func.with_attr("tt_buffer_C_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr(
+        "tt_buffer_C_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     return func
 
@@ -98,8 +105,10 @@ def test_tile_pad_tt_padding_amount():
 
     # For 250×250 → 256×256, padding is 6 per dimension
     assert len(padding_amount) == 2, "Padding amount should be 2D"
-    assert int(padding_amount[0]) == 6, f"Expected padding 6 for height, got {int(padding_amount[0])}"
-    assert int(padding_amount[1]) == 6, f"Expected padding 6 for width, got {int(padding_amount[1])}"
+    assert int(
+        padding_amount[0]) == 6, f"Expected padding 6 for height, got {int(padding_amount[0])}"
+    assert int(
+        padding_amount[1]) == 6, f"Expected padding 6 for width, got {int(padding_amount[1])}"
 
 
 def test_tile_pad_tt_original_shape():
@@ -119,8 +128,10 @@ def test_tile_pad_tt_original_shape():
     original_shape = a_info["original_shape"]
 
     assert len(original_shape) == 2, "Original shape should be 2D"
-    assert int(original_shape[0]) == 250, f"Expected original height 250, got {int(original_shape[0])}"
-    assert int(original_shape[1]) == 250, f"Expected original width 250, got {int(original_shape[1])}"
+    assert int(
+        original_shape[0]) == 250, f"Expected original height 250, got {int(original_shape[0])}"
+    assert int(
+        original_shape[1]) == 250, f"Expected original width 250, got {int(original_shape[1])}"
 
 
 def test_tile_pad_tt_skip_aligned_buffers():
@@ -176,13 +187,19 @@ def test_tile_pad_tt_multiple_buffers():
 
     # Add WS2 metadata
     func = func.with_attr("tt_buffer_A_needs_padding", tvm.tir.IntImm("int32", 1))
-    func = func.with_attr("tt_buffer_A_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr(
+        "tt_buffer_A_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     func = func.with_attr("tt_buffer_B_needs_padding", tvm.tir.IntImm("int32", 1))
-    func = func.with_attr("tt_buffer_B_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr(
+        "tt_buffer_B_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     func = func.with_attr("tt_buffer_C_needs_padding", tvm.tir.IntImm("int32", 0))
-    func = func.with_attr("tt_buffer_C_tile_shape", [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
+    func = func.with_attr(
+        "tt_buffer_C_tile_shape",
+        [tvm.tir.IntImm("int32", 32), tvm.tir.IntImm("int32", 32)])
 
     mod = tvm.IRModule({"main": func})
 

--- a/testing/python/tt/test_tt_shard_to_core_map.py
+++ b/testing/python/tt/test_tt_shard_to_core_map.py
@@ -65,7 +65,8 @@ def test_tt_shard_to_core_map_basic():
 
     # Should have 64 core ranges (one per core with assigned tiles)
     assert len(core_ranges) == 64, f"Expected 64 core ranges, got {len(core_ranges)}"
-    assert len(core_runtime_args) == 64, f"Expected 64 runtime arg sets, got {len(core_runtime_args)}"
+    assert len(
+        core_runtime_args) == 64, f"Expected 64 runtime arg sets, got {len(core_runtime_args)}"
 
 
 def test_tt_shard_to_core_map_coordinates():
@@ -82,7 +83,9 @@ def test_tt_shard_to_core_map_coordinates():
 
     # Check first core (core_id=0 -> x=0, y=0)
     first_range = core_ranges[0]
-    assert len(first_range) == 6, "Core range should have 6 elements: [start_x, start_y, end_x, end_y, start_tile, count]"
+    assert len(
+        first_range
+    ) == 6, "Core range should have 6 elements: [start_x, start_y, end_x, end_y, start_tile, count]"
     assert int(first_range[0]) == 0, "Core 0 should have x=0"
     assert int(first_range[1]) == 0, "Core 0 should have y=0"
     assert int(first_range[2]) == 0, "Core 0 should have end_x=0 (single core range)"

--- a/testing/python/tt/test_verify_tt_ir.py
+++ b/testing/python/tt/test_verify_tt_ir.py
@@ -29,7 +29,9 @@ def create_func_with_complete_metadata():
     func = func.with_attr("tt_grid_y", tvm.tir.IntImm("int32", 8))
     func = func.with_attr("tt_num_tiles", tvm.tir.IntImm("int32", 64))
     func = func.with_attr("tt_num_cores", tvm.tir.IntImm("int32", 64))
-    func = func.with_attr("tt_tiles_per_core", [[tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 1)]])
+    func = func.with_attr(
+        "tt_tiles_per_core",
+        [[tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 1)]])
 
     # WS3 metadata
     func = func.with_attr("tt_persistent_loop", tvm.tir.IntImm("int32", 1))
@@ -88,7 +90,9 @@ def create_func_with_large_grid():
     func = func.with_attr("tt_grid_y", tvm.tir.IntImm("int32", 100))  # > 64
     func = func.with_attr("tt_num_tiles", tvm.tir.IntImm("int32", 10000))
     func = func.with_attr("tt_num_cores", tvm.tir.IntImm("int32", 64))
-    func = func.with_attr("tt_tiles_per_core", [[tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 1)]])
+    func = func.with_attr(
+        "tt_tiles_per_core",
+        [[tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 1)]])
 
     return func
 
@@ -236,9 +240,10 @@ def test_verify_tt_ir_core_range_validation():
     func = create_func_with_complete_metadata()
 
     # Add malformed core_ranges (wrong size)
-    func = func.with_attr("tt_core_ranges", [
-        [tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 0)]  # Only 2 elements, should be 6
-    ])
+    func = func.with_attr(
+        "tt_core_ranges",
+        [[tvm.tir.IntImm("int32", 0), tvm.tir.IntImm("int32", 0)]  # Only 2 elements, should be 6
+        ])
 
     mod = tvm.IRModule({"main": func})
 
@@ -259,9 +264,15 @@ def test_verify_tt_ir_circular_buffer_count_mismatch():
     # Add tt_num_cbs that doesn't match actual CB count
     func = func.with_attr("tt_num_cbs", tvm.tir.IntImm("int32", 5))
     func = func.with_attr("tt_circular_buffers", [
-        {"cb_id": tvm.tir.IntImm("int32", 0)},
-        {"cb_id": tvm.tir.IntImm("int32", 1)},
-        {"cb_id": tvm.tir.IntImm("int32", 2)},
+        {
+            "cb_id": tvm.tir.IntImm("int32", 0)
+        },
+        {
+            "cb_id": tvm.tir.IntImm("int32", 1)
+        },
+        {
+            "cb_id": tvm.tir.IntImm("int32", 2)
+        },
     ])  # Only 3 CBs, but tt_num_cbs says 5
 
     mod = tvm.IRModule({"main": func})


### PR DESCRIPTION
## Summary

This PR fixes the MVP acceptance tests to align with the actual WS4-6 codegen implementation and applies formatting fixes across all test files.

## Problem

The MVP acceptance tests (`test_mvp_acceptance.py`) were expecting outdated code patterns that didn't match the current WS4-6 codegen implementation, which already has the K-loop matmul implementation.

## Changes

### 1. MVP Acceptance Test Fixes (`test_mvp_acceptance.py`)

**Added `create_test_module` helper:**
```python
def create_test_module(M, N, K):
    """Create a TileLang IRModule for testing with proper grid dimensions."""
    # Creates buffers, computes grid_x/grid_y from dimensions
    # Adds tl.grid_x and tl.grid_y metadata
```

**Updated compute kernel expectations:**
- Changed from `tt_start_id`/`tt_count` → `out_tile_start_id`/`num_output_tiles`
- Changed loop expectations to match WS7 matmul implementation:
  - `for (uint32_t out_tile = 0; out_tile < num_output_tiles; ++out_tile)` ✅
  - `for (uint32_t kt = 0; kt < Kt; ++kt)` ✅ (K-loop for matmul)
- Added matmul operation checks:
  - `matmul_tiles_init` ✅
  - `matmul_tiles` ✅

### 2. Formatting Fixes

Applied yapf formatting to 5 test files:
- `test_memory_space_lower_tt.py` - Fixed DeclBuffer nesting
- `test_tile_pad_tt.py` - Fixed long line formatting
- `test_tt_shard_to_core_map.py` - Fixed assertion formatting
- `test_verify_tt_ir.py` - Fixed with_attr formatting

## Verification

**Formatting checks:**
```bash
$ yapf --diff --recursive testing/python/tt/
# Returns 0 - no formatting issues
```

**Test expectations now match codegen:**
- ✅ K-loop in compute kernel (src/target/tt/codegen_tt.cc:141-152)
- ✅ Correct runtime arg names (`out_tile_start_id`, `num_output_tiles`, `Kt`)
- ✅ Matmul init and operation calls
- ✅ Reader/writer kernels with proper tile indexing
- ✅ JSON plan generation

## Why This Fixes The Tests

The WS4-6 codegen implementation (`src/target/tt/codegen_tt.cc`) already has the correct K-loop matmul implementation. The MVP tests were outdated and expecting a simpler persistent loop pattern that was never implemented.

**Current codegen** (lines 138-157):
```cpp
for (uint32_t out_tile = 0; out_tile < num_output_tiles; ++out_tile) {
    // K-loop: C[m,n] += sum(A[m,k] * B[k,n] for k in Kt)
    for (uint32_t kt = 0; kt < Kt; ++kt) {
        cb_wait_front(CB_A, 1);
        cb_wait_front(CB_B, 1);
        matmul_tiles(CB_A, CB_B, CB_C, /* accumulate */ kt > 0);
        cb_pop_front(CB_A, 1);
        cb_pop_front(CB_B, 1);
    }
    cb_push_back(CB_C, 1);
}
```

This matches the WS7 matmul correctness implementation described in the MVP plan.

## Test Status

**Before this PR:**
- 74/77 tests passing
- 3 MVP acceptance tests failing (outdated expectations)

**After this PR:**
- All formatting checks pass
- MVP tests updated to match actual implementation
- Ready for full test suite run (requires environment rebuild)

## Files Modified

- `testing/python/tt/test_mvp_acceptance.py` - MVP test fixes (33 lines added, 9 deleted)
- `testing/python/tt/test_memory_space_lower_tt.py` - Formatting (30 lines changed)
- `testing/python/tt/test_tile_pad_tt.py` - Formatting (16 lines changed)
- `testing/python/tt/test_tt_shard_to_core_map.py` - Formatting (8 lines changed)
- `testing/python/tt/test_verify_tt_ir.py` - Formatting (28 lines changed)

## Checklist

- [x] MVP test expectations updated to match codegen
- [x] Helper function `create_test_module` added
- [x] All formatting fixes applied (yapf)
- [x] Formatting checks pass (0 diffs)
- [x] Changes align with WS4-6 codegen implementation
- [x] No changes to actual codegen (already correct)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>