### PR TITLE
Phase 1.1: DST Foundation + Elementwise Add Infrastructure

### DIFF
--- a/docs/tenstorrent/phases/PHASES_STATUS.md
+++ b/docs/tenstorrent/phases/PHASES_STATUS.md
@@ -1,21 +1,21 @@
 # TileLang→Metalium Compiler: 6-Phase Implementation Status
 
-**Last Updated**: 2025-10-08
-**Overall Progress**: 10% (Phase 1 foundation in progress)
+**Last Updated**: 2025-10-08 (After PR #55)
+**Overall Progress**: 15% (Phase 1 foundation + all specs complete)
 
 ---
 
 ## Quick Status Overview
 
-| Phase | Status | Progress | Duration | Examples | PRs |
-|-------|--------|----------|----------|----------|-----|
-| **Phase 1: Foundation** | 🟡 In Progress | 30% (1/3 examples) | 2 weeks | 3 | 2/? |
-| **Phase 2: Optimizations** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? |
-| **Phase 3: Advanced** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? |
-| **Phase 4: Attention** | ⏳ Not Started | 0% | 2 weeks | 5 | 0/? |
-| **Phase 5: Specialized** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? |
-| **Phase 6: Complex** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? |
-| **TOTAL** | 🟡 10% Complete | **2/20** examples | **12 weeks** | **20** | **2/?** |
+| Phase | Status | Progress | Duration | Examples | PRs | Specs |
+|-------|--------|----------|----------|----------|-----|-------|
+| **Phase 1: Foundation** | 🟡 In Progress | 30% (1/3 examples) | 2 weeks | 3 | 2/? | ✅ Complete |
+| **Phase 2: Optimizations** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? | ✅ Complete |
+| **Phase 3: Advanced** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? | ✅ Complete |
+| **Phase 4: Attention** | ⏳ Not Started | 0% | 2 weeks | 5 | 0/? | ✅ Complete |
+| **Phase 5: Specialized** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? | ✅ Complete |
+| **Phase 6: Complex** | ⏳ Not Started | 0% | 2 weeks | 3 | 0/? | ✅ Complete |
+| **TOTAL** | 🟡 15% Complete | **2/20** examples | **12 weeks** | **20** | **3/?** | **✅ 6/6 phases** |
 
 **Legend**:
 - ✅ Complete
@@ -48,6 +48,14 @@
 - ✅ PR #54: Element-wise DST Pattern Support (MERGED)
   - Enhanced loop detection for element-wise vs K-loop
   - Element-wise example created
+
+- ✅ PR #55: Comprehensive Specs for All 6 Phases (MERGED)
+  - 7 specification documents (1775 lines)
+  - Complete planning for 20 examples across 6 phases
+  - Per-phase implementation roadmaps
+  - Transform requirements documented
+  - Timeline estimates and dependencies
+  - Master status tracking dashboard
 
 ### Pending Work
 

--- a/examples/tenstorrent/example_elementwise_add_tt.py
+++ b/examples/tenstorrent/example_elementwise_add_tt.py
@@ -65,7 +65,6 @@ def elementwise_add_tt(
 
         # Compute C = A + B (element-wise)
         # This should generate: add_tiles_init(); add_tiles(CB_A, CB_B, 0, 0, 0);
-        T.annotate_attr("tt.elementwise_add", 1)
         for i, j in T.grid(32, 32):
             C_tile[i, j] = A_tile[i, j] + B_tile[i, j]
 

--- a/src/target/tt/codegen_tt_compute_visitor.h
+++ b/src/target/tt/codegen_tt_compute_visitor.h
@@ -85,6 +85,12 @@ class TTComputeCodegenVisitor : public TTCodegenVisitor {
   void EmitMatmulIntrinsic(const AttrStmtNode* op);
 
   /*!
+   * \brief Emit element-wise add intrinsic operation
+   * \param op The attribute statement containing elementwise_add annotation
+   */
+  void EmitElementwiseAddIntrinsic(const AttrStmtNode* op);
+
+  /*!
    * \brief Emit CB wait operation
    * \param cb_id Circular buffer ID
    * \param ntiles Number of tiles to wait for


### PR DESCRIPTION
## Summary

This PR implements **Phase 1.1 foundation work** for the TileLang→Metalium compiler, focusing on DST (Destination Register) double buffering and element-wise add infrastructure.

## Changes

### 1. Proper TileLang IR Structure (Example)
- **File**: `examples/tenstorrent/example_elementwise_add_tt.py`
- Created proper grid-style kernel using `T.Kernel(grid_x, grid_y)` pattern
- Follows TileLang conventions with tile allocation, T.copy, and T.grid loops
- Demonstrates Pattern 1 (Element-wise): C = A + B with per-tile DST lifecycle

### 2. Element-wise Intrinsic Codegen Support
- **Files**: `src/target/tt/codegen_tt_compute_visitor.{h,cc}`
- Added `EmitElementwiseAddIntrinsic()` method to handle `tt.elementwise_add` annotations
- Emits:
  - `cb_wait_front(CB_A, 1)` and `cb_wait_front(CB_B, 1)` for inputs
  - `add_tiles_init()` and `add_tiles(CB_A, CB_B, 0, 0, 0)` for computation
  - `cb_pop_front(CB_A, 1)` and `cb_pop_front(CB_B, 1)` for cleanup
- Mock APIs defined in preamble for dry-run testing

### 3. Status Update
- **File**: `docs/tenstorrent/phases/PHASES_STATUS.md`
- Updated overall progress to 15% (from 10%)
- Added PR #55 to completed work section
- Added Specs column showing all 6 phases documented

## Test Results

**DST Double Buffering Status**: ✅ **COMPLETE**
```
  acquire_dst(): ✓ Found
  commit_dst():  ✓ Found
  release_dst(): ✓ Found

✅ PASS: DST double buffering implemented
```

### Generated Compute Kernel Structure
```cpp
void MAIN() {
    uint32_t out_tile_start_id = get_arg_val<uint32_t>(0);
    uint32_t num_output_tiles = get_arg_val<uint32_t>(1);
    
    acquire_dst();  // ✅ DST acquired before computation
    
    // ... tile processing loop ...
    
    cb_reserve_back(CB_C, 1);  // ✅ CB management
    commit_dst();               // ✅ DST committed
    pack_tile(0, CB_C);
    cb_push_back(CB_C, 1);
    release_dst();              // ✅ DST released
}
```

## Current Status

### ✅ Completed
- **DST Lifecycle**: Full acquire→commit→release pattern working
- **Mock APIs**: All necessary intrinsics defined (add_tiles_init, add_tiles, pack_tile)
- **CB Management**: Output buffer operations (cb_reserve_back, cb_push_back)
- **Example Structure**: Proper TileLang grid-style kernel created
- **Codegen Infrastructure**: EmitElementwiseAddIntrinsic method ready
- **Specs**: All 6 phases documented (PR #55)
- **Status Tracking**: PHASES_STATUS.md updated

### ⏳ Pending
- **Pattern Recognition**: Need transform pass or codegen enhancement to detect element-wise patterns
- **Full Intrinsic Emission**: Currently emits scalar loops instead of tile intrinsics (needs pattern recognition)
- **T.copy Integration**: T.copy operations need to be connected to reader/writer kernels

## Implementation Notes

This PR focuses on **foundational infrastructure** for Phase 1.1:
1. **DST double buffering is working** - The core handshake between FPU and Packer is implemented
2. **Codegen hooks are in place** - EmitElementwiseAddIntrinsic ready to emit when pattern is recognized
3. **Example structure is correct** - Using proper TileLang T.Kernel pattern

The next step is to add pattern recognition (either in a transform pass or enhanced codegen) to detect element-wise operations and annotate them with `tt.elementwise_add` so the intrinsic emission triggers.

## Commits

- `fc767eb` - Update PHASES_STATUS.md after PR #55 merge
- `2fe17e1` - Phase 1.1: Add elementwise intrinsic support and proper IR structure
- `20cac96` - Remove invalid T.annotate_attr call from elementwise example

## Related Work

- Builds on PR #53 (DST Double Buffering Foundation) ✅ Merged
- Builds on PR #54 (Element-wise DST Pattern Support) ✅ Merged
- Implements Phase 1.1 spec from PR #55 ✅ Merged

## Testing

```bash
# Run example to see generated code
source .venv/bin/activate
export LD_LIBRARY_PATH=$(pwd)/build/tvm:$LD_LIBRARY_PATH
python examples/tenstorrent/example_elementwise_add_tt.py
```

Expected output: DST double buffering check passes ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Part of**: 6-Phase TileLang→Metalium Compiler Implementation (Phase 1.1 foundation)